### PR TITLE
Reproducible random numbers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Imports:
     testthat,
     tools,
     utils,
-    visNetwork
+    visNetwork,
+    withr
 Suggests:
     abind,
     knitr,

--- a/R/make.R
+++ b/R/make.R
@@ -160,7 +160,9 @@ make = function(plan, targets = drake::possible_targets(plan),
      config$graph = delete_vertices(config$graph, v = delete_these)
      if(parallelism == "Makefile") parallelism = default_parallelism()
   }
-  get(paste0("run_", parallelism), envir = getNamespace("drake"))(config)
+  withr::with_preserve_seed(
+    get(paste0("run_", parallelism), envir = getNamespace("drake"))(config)
+    )
   if(return_config) return(config)
   else invisible()
 }

--- a/tests/testthat/test-reproducible.R
+++ b/tests/testthat/test-reproducible.R
@@ -1,4 +1,4 @@
-context("reproducible")
+context("reproducible random numbers")
 
 test_that("Objects are reproducible", {
   dclean()
@@ -8,14 +8,14 @@ test_that("Objects are reproducible", {
     y = runif(20),
     z = rnorm(20)
     )
-  make(data)
+  make(data, verbose = FALSE)
   old_x <- x
   old_y <- y
   old_z <- z
 
   # Oh no, I've accidentally deleted some data that needs to be reproducible
   clean(x, y, z)
-  make(data)
+  make(data, verbose = FALSE)
   expect_identical(x, old_x)
   expect_identical(y, old_y)
   expect_identical(z, old_z)
@@ -30,7 +30,7 @@ test_that("Objects are distinct", {
     x = runif(20)
     )
   data_exp <- expand(data, values = c("a", "b"))
-  make(data_exp)
+  make(data_exp, verbose = FALSE)
 
   expect_false(identical(x_a, x_b))
 
@@ -51,7 +51,7 @@ test_that("Sequential objects reproduce correctly", {
     methods,
     data = first_stage
     )
-  make(rbind(first_stage, second_stage))
+  make(rbind(first_stage, second_stage), verbose = FALSE)
   old_x <- x
   old_xbax_x <- xbar_x
   old_y_y <- y_x
@@ -59,7 +59,7 @@ test_that("Sequential objects reproduce correctly", {
   # How do I keep deleting my data like this? So clumsy.
   clean(x, xbar_x, y_x)
 
-  make(rbind(first_stage, second_stage))
+  make(rbind(first_stage, second_stage), verbose = FALSE)
   expect_identical(old_x, x)
   expect_identical(old_xbax_x, xbar_x)
   expect_identical(old_y_y, y_x)

--- a/tests/testthat/test-reproducible.R
+++ b/tests/testthat/test-reproducible.R
@@ -8,14 +8,26 @@ test_that("Objects are reproducible", {
     y = runif(20),
     z = rnorm(20)
     )
-  make(data, verbose = FALSE)
-  old_x <- x
+  make(
+    data,
+    envir = dbug()$envir,
+    parallelism = testopts()$parallelism,
+    jobs = testopts()$jobs,
+    verbose = FALSE
+    )
+  old_x <- envir$x
   old_y <- y
   old_z <- z
 
   # Oh no, I've accidentally deleted some data that needs to be reproducible
   clean(x, y, z)
-  make(data, verbose = FALSE)
+  make(
+    data,
+    envir = dbug()$envir,
+    parallelism = testopts()$parallelism,
+    jobs = testopts()$jobs,
+    verbose = FALSE
+    )
   expect_identical(x, old_x)
   expect_identical(y, old_y)
   expect_identical(z, old_z)
@@ -30,7 +42,13 @@ test_that("Objects are distinct", {
     x = runif(20)
     )
   data_exp <- expand(data, values = c("a", "b"))
-  make(data_exp, verbose = FALSE)
+  make(
+    data_exp,
+    envir = dbug()$envir,
+    parallelism = testopts()$parallelism,
+    jobs = testopts()$jobs,
+    verbose = FALSE
+    )
 
   expect_false(identical(x_a, x_b))
 
@@ -51,7 +69,13 @@ test_that("Sequential objects reproduce correctly", {
     methods,
     data = first_stage
     )
-  make(rbind(first_stage, second_stage), verbose = FALSE)
+  make(
+    rbind(first_stage, second_stage),
+    envir = dbug()$envir,
+    parallelism = testopts()$parallelism,
+    jobs = testopts()$jobs,
+    verbose = FALSE
+    )
   old_x <- x
   old_xbax_x <- xbar_x
   old_y_y <- y_x
@@ -59,7 +83,13 @@ test_that("Sequential objects reproduce correctly", {
   # How do I keep deleting my data like this? So clumsy.
   clean(x, xbar_x, y_x)
 
-  make(rbind(first_stage, second_stage), verbose = FALSE)
+  make(
+    rbind(first_stage, second_stage),
+    envir = dbug()$envir,
+    parallelism = testopts()$parallelism,
+    jobs = testopts()$jobs,
+    verbose = FALSE
+    )
   expect_identical(old_x, x)
   expect_identical(old_xbax_x, xbar_x)
   expect_identical(old_y_y, y_x)

--- a/tests/testthat/test-reproducible.R
+++ b/tests/testthat/test-reproducible.R
@@ -1,0 +1,68 @@
+context("reproducible")
+
+test_that("Objects are reproducible", {
+  dclean()
+
+  data <- plan(
+    x = runif(20),
+    y = runif(20),
+    z = rnorm(20)
+    )
+  make(data)
+  old_x <- x
+  old_y <- y
+  old_z <- z
+
+  # Oh no, I've accidentally deleted some data that needs to be reproducible
+  clean(x, y, z)
+  make(data)
+  expect_identical(x, old_x)
+  expect_identical(y, old_y)
+  expect_identical(z, old_z)
+
+  dclean()
+})
+
+test_that("Objects are distinct", {
+  dclean()
+
+  data <- plan(
+    x = runif(20)
+    )
+  data_exp <- expand(data, values = c("a", "b"))
+  make(data_exp)
+
+  expect_false(identical(x_a, x_b))
+
+  dclean()
+})
+
+test_that("Sequential objects reproduce correctly", {
+  dclean()
+
+  first_stage <- plan(
+    x = runif(20)
+    )
+  methods <- plan(
+    xbar = mean(..dataset..),  #nolint
+    y = sample(..dataset.., 5)  #nolint
+    )
+  second_stage <- analyses(
+    methods,
+    data = first_stage
+    )
+  make(rbind(first_stage, second_stage))
+  old_x <- x
+  old_xbax_x <- xbar_x
+  old_y_y <- y_x
+
+  # How do I keep deleting my data like this? So clumsy.
+  clean(x, xbar_x, y_x)
+
+  make(rbind(first_stage, second_stage))
+  expect_identical(old_x, x)
+  expect_identical(old_xbax_x, xbar_x)
+  expect_identical(old_y_y, y_x)
+
+  dclean()
+})


### PR DESCRIPTION
This PR is intended to increase reproducible, by having `make(plan)` preserve `.Random.seed` when building elements.

Includes test file with tests for comparing built and rebuilt objects, and ensuring that objects with same command (generated by `expand`) yield distinct results.

Note: I am getting inconsistent results from `devtools::test()`. Sometimes it will run without any errors, others it will have a lot, even when run sequentially. When I do get errors, it's almost never the same tests as the last run. I'm hoping that it's a quirk of my system, or that I am missing a package that is called in a test, because I get the same behavior on `master` as well. I'm submitting this PR, and hoping that travis can test better than me.