### PR TITLE
58 test configs

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -41,3 +41,98 @@ justbuilt = function(config){
 nobuild = function(config){
   expect_true(length(justbuilt(config)) < 1)
 }
+
+test_configs <- function(){
+  list(
+    list(
+      label = "parent_parL_1",
+      envir = "new.env(parent = globalenv())",
+      parallelism = "parLapply",
+      jobs = 1
+      ), # Uses lapply() instead of parLapply() when jobs = 1.
+    list(
+      label = "parent_parL_2",
+      envir = "new.env(parent = globalenv())",
+      parallelism = "parLapply",
+      jobs = 2,
+      cran = TRUE
+      ), # For CRAN, Travis, and Appveyor, only use this configuration.
+    list(
+      label = "parent_mcl_1",
+      envir = "new.env(parent = globalenv())",
+      parallelism = "mclapply",
+      jobs = 1
+      ), #
+    list(
+      label = "parent_mcl_8",
+      envir = "new.env(parent = globalenv())",
+      parallelism = "mclapply",
+      jobs = 8,
+      skip_os = c("windows")
+      ), # Skip on Windows.
+    list(
+      label = "parent_Make_1",
+      envir = "new.env(parent = globalenv())",
+      parallelism = "Makefile",
+      jobs = 1
+      ), #
+    # Makefiles are different, so I want to test with a low and a
+    # high jobs value.
+    list(
+      label = "parent_Make_2",
+      envir = "new.env(parent = globalenv())",
+      parallelism = "Makefile",
+      jobs = 2
+      ),
+    list(
+      label = "parent_Make_16",
+      envir = "new.env(parent = globalenv())",
+      parallelism = "Makefile",
+      jobs = 16
+      ), #
+    # For the global environment, I do not think all scenarios need to be
+    # repeated.
+    list(
+      label = "global_parL_1",
+      envir = "globalenv()",
+      parallelism = "parLapply",
+      jobs = 1
+      ),
+    list(
+      label = "global_parL_2",
+      envir = "globalenv()",
+      parallelism = "parLapply",
+      jobs = 2
+      ), #
+    list(
+      label = "new_mcl_2",
+      envir = "new.env()",
+      parallelism = "mclapply",
+      jobs = 1
+      ), #
+    list(
+      label = "global_mcl_8",
+      envir = "globalenv()",
+      parallelism = "mclapply",
+      jobs = 8,
+      skip_os = c("windows")
+      ), # Skip on Windows.
+    list(
+      label = "global_Make_16",
+      envir = "globalenv()",
+      parallelism = "Makefile",
+      jobs = 16
+      ) #
+  )
+}
+
+skip_tests <- function(config){
+  if (!(length(config[["CRAN"]]) && config[["CRAN"]])){
+    testthat::skip_on_cran()
+    testthat::skip_on_travis()
+    testthat::skip_on_appveyor()
+  }
+  if (length(config[["skip_os"]])){
+    testthat::skip_on_os(config[["skip_os"]])
+  }
+}

--- a/tests/testthat/test-config_basic.R
+++ b/tests/testthat/test-config_basic.R
@@ -7,7 +7,9 @@ for (config_outer in test_configs()){
 context(paste("basic -", config_outer[["label"]]))
 
 test_that("basic make", {
+  skip_tests(config_outer)
   dclean()
+
   load_basic_example(envir = envir)
   my_plan <- envir$my_plan
 

--- a/tests/testthat/test-config_basic.R
+++ b/tests/testthat/test-config_basic.R
@@ -1,0 +1,277 @@
+for (config_outer in test_configs()){
+  envir <- eval(parse(text = config_outer[["envir"]]))
+  jobs <- config_outer$jobs
+  parallelism <- config_outer$parallelism
+
+
+context(paste("basic -", config_outer[["label"]]))
+
+test_that("basic make", {
+  dclean()
+  load_basic_example(envir = envir)
+  my_plan <- envir$my_plan
+
+  config <- config(
+    envir = envir,
+    plan = my_plan,
+    jobs = jobs,
+    parallelism = parallelism,
+    verbose = FALSE
+    )
+
+  tmp <- plot_graph(
+    my_plan,
+    envir = envir,
+    config = config
+    )
+  expect_false(file.exists("Makefile"))
+
+  tmp <- dataframes_graph(
+    my_plan,
+    envir = envir,
+    config = config
+    )
+  expect_false(file.exists("Makefile"))
+  expect_true(all(sapply(tmp, is.data.frame)))
+
+  tmp <- dataframes_graph(
+    my_plan,
+    envir = envir,
+    config = config
+    )
+  expect_false(file.exists("Makefile"))
+  expect_true(all(sapply(tmp, is.data.frame)))
+
+  expect_equal(
+    sort(outdated(
+        my_plan,
+        envir = envir,
+        config = config
+        )),
+    sort(c(my_plan$target))
+    )
+  expect_false(file.exists("Makefile"))
+
+  file <- "graph.html"
+  expect_false(file.exists(file))
+  plot_graph(
+    my_plan,
+    envir = envir,
+    config = config,
+    file = file
+    )
+  expect_true(file.exists(file))
+  unlink(file)
+  unlink("graph_files", recursive = TRUE)
+  expect_false(file.exists(file))
+
+  expect_equal(
+    max_useful_jobs(
+      envir = envir,
+      plan = my_plan,
+      jobs = jobs,
+      parallelism = parallelism,
+      verbose = FALSE
+      ),
+    8
+    )
+  expect_false(file.exists("Makefile"))
+  expect_equal(
+    max_useful_jobs(
+      envir = envir,
+      plan = my_plan,
+      imports = "files",
+      config = config
+      ),
+    8
+    )
+  expect_true(
+    max_useful_jobs(
+      envir = envir,
+      plan = my_plan,
+      imports = "all",
+      config = config
+      ) > 8
+    )
+  expect_equal(
+    max_useful_jobs(
+      envir = envir,
+      plan = my_plan,
+      imports = "none",
+      config = config
+      ),
+    8
+    )
+
+  make(
+    envir = envir,
+    plan = my_plan,
+    jobs = jobs,
+    parallelism = parallelism,
+    verbose = FALSE
+    )
+  config <- config(
+    envir = envir,
+    plan = my_plan,
+    jobs = jobs,
+    parallelism = parallelism,
+    verbose = FALSE
+    )
+  expect_equal(
+    config_outer$parallelism == "Makefile",
+    file.exists("Makefile")
+    )
+  expect_equal(
+    outdated(
+      my_plan,
+      envir = envir,
+      config = config
+      ),
+    character(0)
+    )
+  expect_equal(
+    max_useful_jobs(
+      envir = envir,
+      plan = my_plan,
+      config = config
+      ),
+    1
+    )
+  expect_equal(
+    max_useful_jobs(
+      envir = envir,
+      plan = my_plan,
+      imports = "files",
+      config = config
+      ),
+    1
+    )
+  expect_true(
+    max_useful_jobs(
+      envir = envir,
+      plan = my_plan,
+      imports = "all",
+      config = config
+      ) > 8
+    )
+  expect_equal(
+    max_useful_jobs(
+      envir = envir,
+      plan = my_plan,
+      imports = "none",
+      config = config
+      ),
+    0
+    )
+
+
+  envir$reg2 <- function(d){
+    d$x3 <- d$x ^ 3
+    lm(y ~ x3, data = d)
+  }
+  config <- config(
+    my_plan,
+    envir = envir,
+    jobs = jobs,
+    parallelism = parallelism,
+    verbose = FALSE)
+  expect_equal(
+    sort(outdated(
+        my_plan,
+        envir = envir,
+        jobs = jobs,
+        config = config
+        )),
+    sort(c(
+      "'report.md'",
+      "coef_regression2_large",
+      "coef_regression2_small",
+      "regression2_large",
+      "regression2_small",
+      "report_dependencies",
+      "summ_regression2_large",
+      "summ_regression2_small"
+      ))
+    )
+  expect_equal(
+    max_useful_jobs(
+      my_plan,
+      envir = envir,
+      config = config
+      ),
+    4
+    )
+  expect_equal(
+    max_useful_jobs(
+      my_plan,
+      envir = envir,
+      imports = "files",
+      config = config
+      ),
+    4
+    )
+  expect_true(
+    max_useful_jobs(
+      my_plan,
+      envir = envir,
+      imports = "all",
+      config = config
+      ) > 8
+    )
+  expect_equal(
+    max_useful_jobs(
+      my_plan,
+      envir = envir,
+      imports = "none",
+      config = config
+      ),
+    4
+    )
+
+  make(
+    envir = envir,
+    plan = my_plan,
+    jobs = jobs,
+    parallelism = parallelism,
+    verbose = FALSE
+    )
+  config <- config(
+    envir = envir,
+    plan = my_plan,
+    jobs = jobs,
+    parallelism = parallelism,
+    verbose = FALSE
+    )
+  expect_equal(
+    config_outer$parallelism == "Makefile",
+    file.exists("Makefile")
+    )
+  expect_equal(
+    outdated(
+      my_plan,
+      envir = envir,
+      config = config
+      ),
+    character(0)
+    )
+
+  tmp <- plot_graph(
+    envir = envir,
+    plan = my_plan,
+    jobs = jobs,
+    parallelism = parallelism,
+    verbose = FALSE
+    )
+  tmp <- dataframes_graph(
+    envir = envir,
+    plan = my_plan,
+    jobs = jobs,
+    parallelism = parallelism,
+    verbose = FALSE
+    )
+  expect_true(all(sapply(tmp, is.data.frame)))
+
+  dclean()
+})
+
+}

--- a/tests/testthat/test-test_configs.R
+++ b/tests/testthat/test-test_configs.R
@@ -1,0 +1,5 @@
+context("test_configs")
+
+test_that("at least one test to run on CRAN", {
+  expect_true(any(unlist(lapply(drake:::test_configs(), `[[`, "cran"))))
+})


### PR DESCRIPTION
This PR introduces a method for testing multiple configurations of options without too much code overhead. Hopefullly this will turn into a solution for issue #58.

I wrapped the whole testfile (I've created `test-config_basic.R` for now) in a `for` loop, with the loop iterating over a nested list of options. The options that I've setup in `test.R` include the environment, the parallelism methods, number of jobs, and if if should be run on CRAN or not. Currently running on travis and appveyor key off the CRAN field, but that could be a change if we want more thorough testing for non-`parLapply` parallelisms.

So far, it is working for the `parLapply`, and `mclapply` (on supported systems), and I can confirm that it does actually skip the `mclapply` tests for `jobs > 1` on Windows,

The bad news is that right now it fails loudly for `Makefile`. (On both windows and Linux). Haven't had a chance to chase that down properly yet.

Goes without saying, but *please do not merge yet.*



