### PR TITLE
Verbose about loading dependency targets

### DIFF
--- a/R/console.R
+++ b/R/console.R
@@ -18,7 +18,7 @@ console_verb_targets <- function(targets, verb, config, color = "slateblue2"){
     return(invisible())
   }
   cat(color(verb, color), " ", n, " item",
-    ifelse(n == 1, "", "s"), ": ", head(targets, 1), 
+    ifelse(n == 1, "", "s"), ": ", head(targets, 1) %>% crop_text(length = 50), 
     ifelse(n == 1, "", ", ..."), "\n", sep = "")
 }
 

--- a/R/console.R
+++ b/R/console.R
@@ -18,8 +18,9 @@ console_verb_targets <- function(targets, verb, config, color = "slateblue2"){
     return(invisible())
   }
   cat(color(verb, color), " ", n, " item",
-    ifelse(n == 1, "", "s"), ": ", head(targets, 1) %>% crop_text(length = 50), 
-    ifelse(n == 1, "", ", ..."), "\n", sep = "")
+    ifelse(n == 1, "", "s"), ": ",
+    targets %>% paste(collapse = ", ") %>% crop_text(length = 50), 
+    "\n", sep = "")
 }
 
 color <- function(x, color) {

--- a/R/console.R
+++ b/R/console.R
@@ -11,14 +11,15 @@ console <- function(imported, target, config) {
   cat(action, " ", target, "\n", sep = "")
 }
 
-console_parallel_stage <- function(targets, config){
+console_verb_targets <- function(targets, verb, config, color = "slateblue2"){
   if (!config$verbose) return(invisible())
   n <- length(targets)
   if (n < 1){
     return(invisible())
   }
-  cat(color("check", "slateblue2"), " ", n, " item",
-    ifelse(n == 1, "", "s"), "\n", sep = "")
+  cat(color(verb, color), " ", n, " item",
+    ifelse(n == 1, "", "s"), ": ", head(targets, 1), 
+    ifelse(n == 1, "", ", ..."), "\n", sep = "")
 }
 
 color <- function(x, color) {

--- a/R/envir.R
+++ b/R/envir.R
@@ -33,6 +33,7 @@ prune_envir <- function(targets, config){
     intersect(y = already_loaded)
   rm(list = discard_these, envir = config$envir)
   if (length(load_these)){
+    console_verb_targets(load_these, "load", config = config)
     loadd(list = load_these, envir = config$envir)
   }
   invisible()

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -11,7 +11,7 @@ parallel_stage <- function(graph_remaining_targets, worker, config) {
   remaining_targets <- V(graph_remaining_targets) %>%
     names %>% intersect(config$targets)
   candidates <- next_targets(graph_remaining_targets)
-  console_parallel_stage(targets = candidates, config = config)
+  console_verb_targets(targets = candidates, verb = "check", config = config)
   hash_list <- hash_list(targets = candidates, config = config)
   build_these <- Filter(candidates,
     f = function(target)

--- a/tests/testthat/test-console.R
+++ b/tests/testthat/test-console.R
@@ -7,7 +7,7 @@ test_with_dir("console", {
   expect_output(console(imported = FALSE, target = "myinput",
     config = config))
   expect_output(
-    console_parallel_stage(targets = letters, config = config))
+    console_verb_targets(targets = letters, verb = "check", config = config))
   x50 <- paste(rep(0:9, 5), collapse = "")
   x51 <- paste0(x50, 0)
   o1 <- capture.output(console(imported = FALSE, target = x50,
@@ -21,15 +21,15 @@ test_with_dir("console", {
   dclean()
 })
 
-test_with_dir("console_parallel_stage() works", {
+test_with_dir("console_verb_targets() works", {
   config <- list(verbose = FALSE)
-  expect_silent(console_parallel_stage(
-    targets = character(0), config = config))
-  expect_silent(console_parallel_stage(
-    targets = "my_target", config = config))
+  expect_silent(console_verb_targets(
+    targets = character(0), verb = "check", config = config))
+  expect_silent(console_verb_targets(
+    targets = "my_target", verb = "check", config = config))
   config <- list(verbose = TRUE)
-  expect_silent(console_parallel_stage(
-    targets = character(0), config = config))
-  expect_output(console_parallel_stage(
-    targets = "my_target", config = config))
+  expect_silent(console_verb_targets(
+    targets = character(0), verb = "check", config = config))
+  expect_output(console_verb_targets(
+    targets = "my_target", verb = "check", config = config))
 })


### PR DESCRIPTION
This is another bottleneck for my usage of drake, so it would be nice to have output here that shows why drake is stalling. I also generalized your console_parallel_stage function for this purpose! This slightly changes the output of the previous console_parallel_stage "check n items" output, to print some target names.