### PR TITLE
Use message() instead of cat()

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -93,15 +93,14 @@ check_strings <- function(plan) {
     if (length(y) > 2)
       return(y[seq(from = 1, to = length(y), by = 2)]) else return(y)
   })
-  cat("Double-quoted strings were found in plan$command.",
-    "Should these be single-quoted instead?",
-    "Remember: single-quoted strings are file target dependencies",
-    "and double-quoted strings are just ordinary strings.",
-    sep = "\n")
+  message("Double-quoted strings were found in plan$command.\n",
+    "Should these be single-quoted instead?\n",
+    "Remember: single-quoted strings are file target dependencies\n",
+    "and double-quoted strings are just ordinary strings.")
   for (target in seq_len(length(x))) {
-    cat("\ntarget:", names(x)[target], "\n")
-    cat("strings in command:\n",
+    message("\ntarget: ", names(x)[target])
+    message("strings in command:\n",
       multiline_message(eply::quotes(x[[target]],
-      single = FALSE)), "\n", sep = "")
+      single = FALSE)), sep = "")
   }
 }

--- a/R/clean.R
+++ b/R/clean.R
@@ -47,6 +47,10 @@
 #' @param jobs Number of jobs for light parallelism
 #' (disabled on Windows).
 #'
+#' @param force logical, whether to try to clean the cache
+#' even though the project may not be back compatible with the
+#' current version of drake.
+#'
 #' @examples
 #' \dontrun{
 #' load_basic_example()
@@ -66,12 +70,14 @@ clean <- function(
   search = TRUE,
   cache = NULL,
   verbose = TRUE,
-  jobs = 1
+  jobs = 1,
+  force = FALSE
 ){
   dots <- match.call(expand.dots = FALSE)$...
   targets <- targets_from_dots(dots, list)
   if (is.null(cache)){
-    cache <- get_cache(path = path, search = search, verbose = verbose)
+    cache <- get_cache(
+      path = path, search = search, verbose = verbose, force = force)
   }
   if (is.null(cache)){
     return(invisible())

--- a/R/color.R
+++ b/R/color.R
@@ -45,7 +45,7 @@ drake_palette <- function(){
     }
   )
   out <- paste(out, collapse = "\n")
-  cat(out, "\n")
+  message(out)
 }
 
 color <- function(x, color) {

--- a/R/console.R
+++ b/R/console.R
@@ -79,15 +79,15 @@ console_up_to_date <- function(config){
   any_attempted <- length(config$cache$list(namespace = "attempts"))
   default_triggers <- using_default_triggers(config)
   if (!any_attempted && default_triggers){
-    color("All targets are already up to date.\n", colors["target"]) %>%
-      cat
+    color("All targets are already up to date.", colors["target"]) %>%
+      message
   } else if (!default_triggers){
     color(
       paste(
         "Used non-default triggers.",
-        "Some targets may be not be up to date.\n"),
+        "Some targets may be not be up to date."),
       colors["trigger"]) %>%
-      cat
+      message
   }
 }
 
@@ -97,7 +97,7 @@ finish_console <- function(text, pattern, verbose){
   }
   crop_text(x = text, length = console_length) %>%
     color_grep(pattern = pattern, color = color_of(pattern)) %>%
-    cat("\n", sep = "")
+    message(sep = "")
 }
 
 crop_text <- Vectorize(function(x, length = 50) {

--- a/R/graph.R
+++ b/R/graph.R
@@ -160,10 +160,10 @@ assert_unique_names <- function(imports, targets, envir, verbose){
   }
   common <- intersect(imports, targets)
   if (verbose & length(common)){
-    cat(
+    message(
       "Unloading targets from environment:\n",
-      multiline_message(common), "\n", sep = ""
-      )
+      multiline_message(common), sep = ""
+    )
   }
   remove(list = common, envir = envir)
 }

--- a/R/make.R
+++ b/R/make.R
@@ -48,7 +48,7 @@
 #' that builds a target, and make sure this argument is actually evaluated.
 #' Otherwise, the code will not run and none of your targets will build.
 #' For example, \code{function(code){force(code)}} is a good hook
-#' and \code{function(code){cat("Avoiding the code")}} is a bad hook.
+#' and \code{function(code){message("Avoiding the code")}} is a bad hook.
 #'
 #' @param imports_only logical, whether to skip building the targets
 #' in \code{plan} and just import objects and files.

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -41,10 +41,10 @@ migrate <- function(path = drake::default_cache_path(), jobs = 1){
   }
   version <- session(cache = cache)$otherPkgs$drake$Version # nolint
   backup <- backup_cache_path(path = path, old = version)
-  cat("Backing up", path, "to a backup cache at ", backup, "\n")
+  message("Backing up", path, "to a backup cache at ", backup)
   dir.create(backup)
   file.copy(from = path, to = backup, recursive = TRUE)
-  cat("Migrating cache at", path, "for your system's drake.\n")
+  message("Migrating cache at", path, "for your system's drake.")
   config <- read_config(cache = cache)
   config$cache <- cache
   config$parallelism <- "mclapply"
@@ -58,7 +58,7 @@ migrate <- function(path = drake::default_cache_path(), jobs = 1){
   config$cache$clear(namespace = "depends")
   store_config(config = config)
   run_mclapply(config = config)
-  cat("Checking for outdated targets.\n")
+  message("Checking for outdated targets.")
   config$hook <- empty_hook
   outdated <- outdated(config = config) %>%
     sort
@@ -74,11 +74,11 @@ should_migrate <- function(path){
   tryCatch({
       tmp <- this_cache(path = path, force = FALSE)
       if (is.null(tmp)){
-        cat("No cache found to migrate.\n")
+        message("No cache found to migrate.")
       } else {
-        cat(
-          "This project is already compatible with your system's drake.",
-          "No need to migrate.\n"
+        message(
+          "This project is already compatible with your system's drake. ",
+          "No need to migrate."
         )
       }
       NULL
@@ -171,18 +171,18 @@ migration_result <- function(success, backup){
 }
 
 migration_failure <- function(backup){
-  paste(
-    "Migration failed:",
-    "target statuses failed to transfer (outdated vs current).",
-    "Original cache saved:", backup
+  paste0(
+    "migration failed: ",
+    "target statuses failed to transfer (outdated vs current). ",
+    "Original cache saved: ", backup
   ) %>%
     stop(call. = FALSE)
 }
 
 migration_success <- function(){
-  cat(
-    "Migration successful:",
-    "target statuses preserved (outdated vs current).\n"
+  message(
+    "Migration successful: ",
+    "target statuses preserved (outdated vs current)."
   )
 }
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -74,7 +74,7 @@ Makefile_recipe <- function( # nolint
     recipe_command = recipe_command,
     cache_path = cache_path
   ) %>%
-    cat("\n")
+    message()
 }
 
 #' @title default_recipe_command

--- a/R/test.R
+++ b/R/test.R
@@ -44,10 +44,7 @@ test_with_dir <- function(desc, ...){
     new = new,
     code = {
       set_test_backend()
-      tmp <- capture.output(
-        test_that(desc = desc, ...),
-        type = "message"
-      )
+      test_that(desc = desc, ...)
     }
   )
   invisible()

--- a/R/test.R
+++ b/R/test.R
@@ -45,7 +45,8 @@ test_with_dir <- function(desc, ...){
     code = {
       set_test_backend()
       tmp <- capture.output(
-        test_that(desc = desc, ...)
+        test_that(desc = desc, ...),
+        type = "message"
       )
     }
   )

--- a/R/test_scenarios.R
+++ b/R/test_scenarios.R
@@ -95,7 +95,7 @@ test_scenarios <- function(
   for (scenario_name in scenario_names){
     skip <- skip_criterion(scenario_name)
     msg <- ifelse(skip, "skip", "run")
-    cat(scenario_name, ": ", msg, "\n", sep = "")
+    message(scenario_name, ": ", msg, sep = "")
     new <- list()
     new[[test_option_name]] <- scenario_name
     if (!skip) {

--- a/R/tips.R
+++ b/R/tips.R
@@ -4,7 +4,7 @@
 #' @export
 #' @examples
 #' drake_tip()
-#' cat(drake_tip())
+#' message(drake_tip())
 drake_tip <- function() {
   tips <- c(
     "In drake >= 4.4.0, you can select subgraphs of the workflow graph:

--- a/man/clean.Rd
+++ b/man/clean.Rd
@@ -5,7 +5,8 @@
 \title{Function \code{clean}}
 \usage{
 clean(..., list = character(0), destroy = FALSE, path = getwd(),
-  search = TRUE, cache = NULL, verbose = TRUE, jobs = 1)
+  search = TRUE, cache = NULL, verbose = TRUE, jobs = 1,
+  force = FALSE)
 }
 \arguments{
 \item{...}{targets to remove from the cache, as names (unquoted)
@@ -41,6 +42,10 @@ the \code{path} and \code{search} arguments are ignored.}
 
 \item{jobs}{Number of jobs for light parallelism
 (disabled on Windows).}
+
+\item{force}{logical, whether to try to clean the cache
+even though the project may not be back compatible with the
+current version of drake.}
 }
 \description{
 Cleans up all work done by \code{\link{make}()}.

--- a/man/drake_tip.Rd
+++ b/man/drake_tip.Rd
@@ -12,5 +12,5 @@ Tips are usually related to news and usage.
 }
 \examples{
 drake_tip()
-cat(drake_tip())
+message(drake_tip())
 }

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -57,7 +57,7 @@ For your own custom hooks, treat the first argument as the code
 that builds a target, and make sure this argument is actually evaluated.
 Otherwise, the code will not run and none of your targets will build.
 For example, \code{function(code){force(code)}} is a good hook
-and \code{function(code){cat("Avoiding the code")}} is a bad hook.}
+and \code{function(code){message("Avoiding the code")}} is a bad hook.}
 
 \item{cache}{drake cache as created by \code{\link{new_cache}()}.
 See also \code{\link{get_cache}()}, \code{\link{this_cache}()},

--- a/tests/testthat/test-Makefile.R
+++ b/tests/testthat/test-Makefile.R
@@ -1,8 +1,8 @@
 drake_context("Makefile")
 
 test_with_dir("recipe commands", {
-  expect_output(Makefile_recipe())
-  expect_output(Makefile_recipe(recipe_command = "R -e 'R_RECIPE' -q"))
+  expect_message(Makefile_recipe())
+  expect_message(Makefile_recipe(recipe_command = "R -e 'R_RECIPE' -q"))
   my_plan <- workplan(y = 1)
   expect_true(is.character(default_recipe_command()))
   expect_true(is.character(r_recipe_wildcard()))

--- a/tests/testthat/test-console.R
+++ b/tests/testthat/test-console.R
@@ -47,19 +47,27 @@ test_with_dir("console", {
   x1 <- "12345"
   x2 <- paste(rep(0:9, length.out = console_length + 400), collapse = "")
   expect_equal(x1, color(x = x1, color = NULL))
-  o1 <- capture.output(console(imported = FALSE, target = x1,
-    config = config), type = "message")
-  o2 <- capture.output(console(imported = FALSE, target = x2,
-    config = config), type = "message")
-  
-  # testthat redirects messages somehow.
-  if (FALSE){
-    expect_true(nchar(o1) < console_length)
-    expect_true(nchar(o2) < console_length + 20)
-    dots <- "\\.\\.\\.$"
-    expect_false(grepl(dots, o1))
-    expect_true(grepl(dots, o2))
-  }
+  o1 <- evaluate_promise(
+    console(
+      imported = FALSE,
+      target = x1,
+      config = config
+    ),
+    print = TRUE
+  )$messages
+  o2 <- evaluate_promise(
+    console(
+      imported = FALSE,
+      target = x2,
+      config = config
+    ),
+    print = TRUE
+  )$messages
+  expect_true(nchar(o1) < console_length)
+  expect_true(nchar(o2) < console_length + 20)
+  dots <- "\\.\\.\\.\n$"
+  expect_false(grepl(dots, o1))
+  expect_true(grepl(dots, o2))
 })
 
 test_with_dir("console_many_targets() works", {
@@ -73,17 +81,14 @@ test_with_dir("console_many_targets() works", {
     targets = character(0), pattern = "check", config = config))
   expect_message(console_many_targets(
     targets = "my_target", pattern = "check", config = config))
-  tmp <- capture.output(
+  tmp <- evaluate_promise(
     console_many_targets(
       targets = LETTERS,
       pattern = unique_random_string(n = 400),
       config = config
     ),
-    type = "message"
-  )
-  # testthat redirects messages somehow.
-  if (FALSE){
-    expect_true(is.character(tmp))
-    expect_true(nchar(tmp) <= console_length + 20)
-  }
+    print = TRUE
+  )$messages
+  expect_true(is.character(tmp))
+  expect_true(nchar(tmp) <= console_length + 20)
 })

--- a/tests/testthat/test-console.R
+++ b/tests/testthat/test-console.R
@@ -8,12 +8,12 @@ test_with_dir("console_up_to_date", {
   expect_silent(console_up_to_date(con))
   con <- make(pl, verbose = FALSE)
   con$verbose <- TRUE
-  expect_output(console_up_to_date(con))
+  expect_message(console_up_to_date(con))
 })
 
 test_with_dir("console_parLapply", {
   config <- list(verbose = TRUE)
-  expect_output(console_parLapply(config = config)) # nolint
+  expect_message(console_parLapply(config = config)) # nolint
   config <- list(verbose = FALSE)
   expect_silent(console_parLapply(config = config)) # nolint
 })
@@ -33,13 +33,13 @@ test_with_dir("multiline message cap", {
 test_with_dir("console", {
   config <- dbug()
   config$verbose <- TRUE
-  expect_output(console(imported = FALSE, target = "myinput",
+  expect_message(console(imported = FALSE, target = "myinput",
     config = config))
-  expect_output(console(imported = TRUE, target = "myinput",
+  expect_message(console(imported = TRUE, target = "myinput",
     config = config))
-  expect_output(console(imported = NA, target = "myinput",
+  expect_message(console(imported = NA, target = "myinput",
     config = config))
-  expect_output(
+  expect_message(
     console_many_targets(targets = letters,
       pattern = "check", config = config
     )
@@ -48,14 +48,18 @@ test_with_dir("console", {
   x2 <- paste(rep(0:9, length.out = console_length + 400), collapse = "")
   expect_equal(x1, color(x = x1, color = NULL))
   o1 <- capture.output(console(imported = FALSE, target = x1,
-    config = config))
+    config = config), type = "message")
   o2 <- capture.output(console(imported = FALSE, target = x2,
-    config = config))
-  expect_true(nchar(o1) < console_length)
-  expect_true(nchar(o2) < console_length + 20)
-  dots <- "\\.\\.\\.$"
-  expect_false(grepl(dots, o1))
-  expect_true(grepl(dots, o2))
+    config = config), type = "message")
+  
+  # testthat redirects messages somehow.
+  if (FALSE){
+    expect_true(nchar(o1) < console_length)
+    expect_true(nchar(o2) < console_length + 20)
+    dots <- "\\.\\.\\.$"
+    expect_false(grepl(dots, o1))
+    expect_true(grepl(dots, o2))
+  }
 })
 
 test_with_dir("console_many_targets() works", {
@@ -67,15 +71,19 @@ test_with_dir("console_many_targets() works", {
   config <- list(verbose = TRUE)
   expect_silent(console_many_targets(
     targets = character(0), pattern = "check", config = config))
-  expect_output(console_many_targets(
+  expect_message(console_many_targets(
     targets = "my_target", pattern = "check", config = config))
   tmp <- capture.output(
     console_many_targets(
       targets = LETTERS,
       pattern = unique_random_string(n = 400),
       config = config
-    )
+    ),
+    type = "message"
   )
-  expect_true(is.character(tmp))
-  expect_true(nchar(tmp) <= console_length + 20)
+  # testthat redirects messages somehow.
+  if (FALSE){
+    expect_true(is.character(tmp))
+    expect_true(nchar(tmp) <= console_length + 20)
+  }
 })

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -59,7 +59,7 @@ test_with_dir("tracked() works", {
 
 test_with_dir("missing files via check()", {
   config <- dbug()
-  expect_output(check(config$plan, envir = config$envir))
+  expect_message(check(config$plan, envir = config$envir))
   expect_silent(tmp <- missing_input_files(config))
   unlink("input.rds", force = TRUE)
   expect_warning(

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -138,8 +138,8 @@ test_with_dir("target conflicts with current import or another target", {
   config <- dbug()
   config$plan <- rbind(config$plan, data.frame(target = "f",
     command = "1+1"))
-  expect_silent(tmp <- capture.output(check(plan = config$plan,
-    envir = config$envir)))
+  expect_message(check(plan = config$plan,
+    envir = config$envir))
   config$plan$target <- "repeated"
   expect_error(check(plan = config$plan))
 })

--- a/tests/testthat/test-import-file.R
+++ b/tests/testthat/test-import-file.R
@@ -2,7 +2,7 @@ drake_context("import file")
 
 test_with_dir("responses to imported file", {
   config <- dbug()
-  expect_output(check(plan = config$plan, envir = config$envir))
+  expect_message(check(plan = config$plan, envir = config$envir))
   expect_warning(
     check(plan = config$plan[-1, ], envir = config$envir,
           verbose = FALSE))

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -65,7 +65,7 @@ test_with_dir("migrate() a partially outdated cache", {
 
 test_with_dir("migration_result()", {
   expect_error(migration_result(FALSE, "backup"))
-  expect_output(migration_result(TRUE, "backup"))
+  expect_message(migration_result(TRUE, "backup"))
 })
 
 test_with_dir("Null cases in legacy functions", {

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -86,10 +86,22 @@ test_with_dir("Null cases in legacy functions", {
   expect_true(is.na(error_na()))
 })
 
-test_with_dir("more legacy functions", {
+test_with_dir("edge cases in the legacy functions. (no glaring errors)", {
   con <- dbug()
   testrun(con)
-  file.rename("intermediatefile.rds", "tmp")
-  expect_false(legacy_target_current("'intermediatefile.rds'", hashes = list(),
-    config = list(inventory = "'intermediatefile.rds'")))
+  target <- "'intermediatefile.rds'"
+
+  # Force legacy_file_hash() to rehash a file.
+  con$cache$set(key = target, value = Inf, namespace = "filemtime")
+  expect_true(
+    is.character(
+      legacy_file_hash(
+        target = target, config = con, size_cutoff = -1
+      )
+    )
+  )
+
+  # Force legacy_target_current() to show a target out of date.
+  expect_false(legacy_target_current(target, hashes = list(),
+    config = con))
 })

--- a/tests/testthat/test-other-features.R
+++ b/tests/testthat/test-other-features.R
@@ -17,7 +17,7 @@ test_with_dir("lightly_parallelize_atomic() is correct", {
 })
 
 test_with_dir("colors and shapes", {
-  expect_output(drake_palette())
+  expect_message(drake_palette())
   expect_is(color_of("target"), "character")
   expect_is(color_of("import"), "character")
   expect_is(color_of("not found"), "character")

--- a/tests/testthat/test-testing.R
+++ b/tests/testthat/test-testing.R
@@ -95,18 +95,16 @@ test_with_dir("test_scenarios()", {
   log <- gsub(" .*", "", log)
   expect_equal(sort(log), sort(testing_scenario_names()))
 
-  log <- capture.output(
+  log <- evaluate_promise(
     test_scenarios(
       unit_test_dir = subdir,
       skip_criterion = always_skip
     ),
-    type = "message"
+    print = TRUE
   )
+  log <- c(log$output, log$messages)
+
   loggings <- grepl("logged scenario", log)
-  
-  # testthat suppresses messages somehow
-  if (FALSE){
-    expect_false(any(loggings))
-    expect_true(any(grepl("skip", log)))
-  }
+  expect_false(any(loggings))
+  expect_true(any(grepl("skip", log)))
 })

--- a/tests/testthat/test-testing.R
+++ b/tests/testthat/test-testing.R
@@ -99,9 +99,14 @@ test_with_dir("test_scenarios()", {
     test_scenarios(
       unit_test_dir = subdir,
       skip_criterion = always_skip
-    )
+    ),
+    type = "message"
   )
   loggings <- grepl("logged scenario", log)
-  expect_false(any(loggings))
-  expect_true(any(grepl("skip", log)))
+  
+  # testthat suppresses messages somehow
+  if (FALSE){
+    expect_false(any(loggings))
+    expect_true(any(grepl("skip", log)))
+  }
 })


### PR DESCRIPTION
The rOpenSci package guidelines recommend this because output from cat() is harder for users to suppress.