### PR TITLE
Improve the solution to #144

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -113,8 +113,7 @@ drake_config <- function(
   trigger <- match.arg(arg = trigger, choices = triggers())
   if (is.null(graph)){
     graph <- build_drake_graph(plan = plan, targets = targets,
-      envir = envir, verbose = verbose, jobs = jobs,
-      skip_imports = skip_imports)
+      envir = envir, verbose = verbose, jobs = jobs)
   } else {
     graph <- prune_drake_graph(graph = graph, to = targets, jobs = jobs)
   }

--- a/R/console.R
+++ b/R/console.R
@@ -99,7 +99,7 @@ console_skipped_imports <- function(){
   color(
     paste(
       "Skipped the imports.",
-      "Targets are almost surely out of date."
+      "If some imports are not already cached, targets could be out of date."
     ),
     colors["trigger"]
   ) %>%

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -132,10 +132,6 @@ dependency_profile <- function(target, config){
 #' parallelism is used if your operating system is not Windows.
 #' @param verbose logical, whether to print
 #' progress messages to the console.
-#' @param skip_imports logical, whether to totally neglect to
-#' process the imports and jump straight to the targets. This can be useful
-#' if your imports are massive and you just want to test your project,
-#' but it is bad practice for reproducible data analysis.
 #' @examples
 #' \dontrun{
 #' load_basic_example() # Load the canonical example for drake.
@@ -147,13 +143,12 @@ tracked <- function(
   targets = drake::possible_targets(plan),
   envir = parent.frame(),
   jobs = 1,
-  verbose = TRUE,
-  skip_imports = FALSE
+  verbose = TRUE
 ){
   force(envir)
   graph <- build_drake_graph(
     plan = plan, targets = targets, envir = envir,
-    jobs = jobs, verbose = verbose, skip_imports = skip_imports
+    jobs = jobs, verbose = verbose
   )
   V(graph)$name
 }

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -90,10 +90,15 @@ backend <- function(...){
 #' @param envir Same as for \code{\link{build_drake_graph}()}.
 #' @param verbose Same as for \code{\link{build_drake_graph}()}.
 #' @param jobs Same as for \code{\link{build_drake_graph}()}.
-#' @param skip_imports Same as for \code{\link{build_drake_graph}()}.
 #' @examples
 #' # See ?as_drake_filename for examples.
-build_graph <- function(x){
+build_graph <- function(
+  plan = workplan(),
+  targets = drake::possible_targets(plan),
+  envir = parent.frame(),
+  verbose = TRUE,
+  jobs = 1
+){
   .Deprecated(
     "backend",
     package = "drake",
@@ -103,7 +108,10 @@ build_graph <- function(x){
       "Use build_drake_graph() instead."
     )
   )
-  build_drake_graph(x)
+  build_drake_graph(
+    plan = plan, targets = targets, envir = envir, verbose = verbose,
+    jobs = jobs
+  )
 }
 
 #' @title Deprecated function \code{check}

--- a/R/distributed.R
+++ b/R/distributed.R
@@ -8,7 +8,7 @@ prepare_distributed <- function(config){
     )
   }
   config$cache$set(key = "envir", value = config$envir, namespace = "config")
-  attempts <- outdated(config = config)
+  attempts <- outdated(config = config, make_imports = !config$skip_imports)
   log_attempts(targets = attempts, config = config)
   invisible()
 }

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -7,6 +7,7 @@ run_parallel_backend <- function(config){
 
 run_parallel <- function(config, worker) {
   config$graph_remaining_targets <- config$graph
+  config <- exclude_imports_if(config)
   while (length(V(config$graph_remaining_targets))){
     config <- parallel_stage(worker = worker, config = config)
   }

--- a/man/build_drake_graph.Rd
+++ b/man/build_drake_graph.Rd
@@ -6,7 +6,7 @@
 \usage{
 build_drake_graph(plan = workplan(),
   targets = drake::possible_targets(plan), envir = parent.frame(),
-  verbose = TRUE, jobs = 1, skip_imports = FALSE)
+  verbose = TRUE, jobs = 1)
 }
 \arguments{
 \item{plan}{workflow plan data frame, same as for function
@@ -23,11 +23,6 @@ build_drake_graph(plan = workplan(),
 \item{jobs}{number of jobs to accelerate the construction
 of the dependency graph. A light \code{mclapply}-based
 parallelism is used if your operating system is not Windows.}
-
-\item{skip_imports}{logical, whether to totally neglect to
-process the imports and jump straight to the targets. This can be useful
-if your imports are massive and you just want to test your project,
-but it is bad practice for reproducible data analysis.}
 }
 \value{
 An igraph object representing

--- a/man/build_graph.Rd
+++ b/man/build_graph.Rd
@@ -4,7 +4,8 @@
 \alias{build_graph}
 \title{Deprecated function \code{build_graph}}
 \usage{
-build_graph(x)
+build_graph(plan = workplan(), targets = drake::possible_targets(plan),
+  envir = parent.frame(), verbose = TRUE, jobs = 1)
 }
 \arguments{
 \item{plan}{Same as for \code{\link{build_drake_graph}()}.}
@@ -16,8 +17,6 @@ build_graph(x)
 \item{verbose}{Same as for \code{\link{build_drake_graph}()}.}
 
 \item{jobs}{Same as for \code{\link{build_drake_graph}()}.}
-
-\item{skip_imports}{Same as for \code{\link{build_drake_graph}()}.}
 }
 \value{
 The same return value as \code{\link{build_drake_graph}()}.

--- a/man/tracked.Rd
+++ b/man/tracked.Rd
@@ -5,8 +5,7 @@
 \title{Function \code{tracked}}
 \usage{
 tracked(plan = workplan(), targets = drake::possible_targets(plan),
-  envir = parent.frame(), jobs = 1, verbose = TRUE,
-  skip_imports = FALSE)
+  envir = parent.frame(), jobs = 1, verbose = TRUE)
 }
 \arguments{
 \item{plan}{workflow plan data frame, same as for function
@@ -24,11 +23,6 @@ parallelism is used if your operating system is not Windows.}
 
 \item{verbose}{logical, whether to print
 progress messages to the console.}
-
-\item{skip_imports}{logical, whether to totally neglect to
-process the imports and jump straight to the targets. This can be useful
-if your imports are massive and you just want to test your project,
-but it is bad practice for reproducible data analysis.}
 }
 \value{
 A character vector with the names of reproducibly-tracked targets.

--- a/tests/testthat/test-triggers.R
+++ b/tests/testthat/test-triggers.R
@@ -110,4 +110,19 @@ test_with_dir("make(..., skip_imports = TRUE) works", {
     )
   )
   expect_equal(sort(cached()), sort(con$plan$target))
+
+  # If the imports are already cached, the targets built with
+  # skip_imports = TRUE should be up to date.
+  make(con$plan, verbose = FALSE, envir = con$envir)
+  clean(list = con$plan$target, verbose = FALSE)
+  suppressMessages(
+    con <- make(
+      con$plan, parallelism = con$parallelism,
+      envir = con$envir, jobs = con$jobs, verbose = verbose,
+      hook = silencer_hook,
+      skip_imports = TRUE
+    )
+  )
+  out <- outdated(con$plan, envir = con$envir, verbose = FALSE)
+  expect_equal(out, character(0))
 })

--- a/vignettes/caution.Rmd
+++ b/vignettes/caution.Rmd
@@ -244,7 +244,7 @@ You can call `make(..., timeout = 10)` to time out all each target after 10 seco
 
 ## Triggers and skipped imports
 
-With alternate [triggers](https://github.com/wlandau-lilly/drake/blob/master/vignettes/debug.Rmd#test-with-triggers) and the [option to skip imports](https://github.com/wlandau-lilly/drake/blob/master/vignettes/debug.Rmd#skipping-imports), you can sacrifice reproducibility to gain speed. However, these options throw the dependency network out of sync. You should only use them for testing and debugging, never for production.
+With alternate [triggers](https://github.com/wlandau-lilly/drake/blob/master/vignettes/debug.Rmd#test-with-triggers) and the [option to skip imports](https://github.com/wlandau-lilly/drake/blob/master/vignettes/debug.Rmd#skipping-imports), you can sacrifice reproducibility to gain speed. However, these options can throw the dependency network out of sync. You should only use them for testing and debugging, never for production.
 
 ## Dependencies are not tracked in some edge cases.
 

--- a/vignettes/debug.Rmd
+++ b/vignettes/debug.Rmd
@@ -167,7 +167,7 @@ make(my_plan, trigger = "any") # Nothing changes!
 
 # Skipping imports
 
-Similar to triggers, another way to speed testing is to skip the imports entirely. However, *you should only use this for testing purposes* because it puts your targets out of sync with your imports. In other words, `outdated()` will almost certainly flag any targets you build this way.. Hence, your work is no longer reproducible, and `drake` is reduced to an ordinary unopinionated job scheduler.
+Similar to triggers, another way to speed testing is to skip the imports entirely. However, *you should only use this for testing purposes*. If some of your imports are not already cached and up to date, any built targets will be out of sync. In other words, you risk false positive findings in `outdated()`, and your project may no longer be reproducibly interconnected.
 
 ```{r skipimports}
 clean(verbose = FALSE)

--- a/vignettes/drake.Rmd
+++ b/vignettes/drake.Rmd
@@ -222,7 +222,7 @@ Similarly to imported functions like `reg2()`, `drake` reacts to changes in
 1. Upstream targets.
 1. For [dynamic knitr reports](https://yihui.name/knitr/) (with `knit('your_report.Rmd')` as a command in your workflow plan data frame), targets and imports mentioned in calls to `readd()` and `loadd()` in the code chunks to be evaluated. `Drake` treats these targets and imports as dependencies of the compiled output target (say, `report.md`).
 
-With alternate [triggers](https://github.com/wlandau-lilly/drake/blob/master/vignettes/debug.Rmd#test-with-triggers) and the [option to skip imports](https://github.com/wlandau-lilly/drake/blob/master/vignettes/debug.Rmd#skipping-imports), you can sacrifice reproducibility to gain speed. However, these options throw the dependency network out of sync. You should only use them for testing and debugging, never for production.
+With alternate [triggers](https://github.com/wlandau-lilly/drake/blob/master/vignettes/debug.Rmd#test-with-triggers) and the [option to skip imports](https://github.com/wlandau-lilly/drake/blob/master/vignettes/debug.Rmd#skipping-imports), you can sacrifice reproducibility to gain speed. However, these options can throw the dependency network out of sync. You should only use them for testing and debugging, never for production.
 
 ```{r triggermissingdrake, eval = FALSE}
 make(..., skip_imports = TRUE, trigger = "missing")


### PR DESCRIPTION
Also relates to part of the thread for #131. Previously, the `skip_imports` option put targets out of date. Now, as long as your imports are cached and up to date beforehand, any built targets will be up to date. This is unit tested at the end of `test-triggers.R`.