### PR TITLE
Add option to suppress sessionInfo()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@
 - Add a `namespace` argument to `cached()` so users can inspect individual `storr` namespaces.
 - Change `verbose` to numeric: 0 = print nothing, 1 = print progress on imports only, 2 = print everything.
 - Add a new `next_stage()` function to report the targets to be made in the next parallelizable stage.
+- Add a new `session_info` argument to `make()`. Apparently, `sessionInfo()` is a bottleneck for small `make()`s, so there is now an option to suppress it. This is mostly for the sake of speeding up unit tests.
 
 # Changes in release 4.4.0
 

--- a/R/config.R
+++ b/R/config.R
@@ -54,6 +54,7 @@
 #' on your workflow to save time. Use at your own peril.
 #' @param store_meta same as for \code{\link{make}}
 #' @param lazy_load same as for \code{\link{make}}
+#' @param session_info same as for \code{\link{make}}
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -102,7 +103,8 @@ drake_config <- function(
   skip_imports = FALSE,
   skip_safety_checks = FALSE,
   store_meta = TRUE,
-  lazy_load = FALSE
+  lazy_load = FALSE,
+  session_info = TRUE
 ){
   force(envir)
   seed <- get_valid_seed()
@@ -146,7 +148,7 @@ drake_config <- function(
     timeout = timeout, cpu = cpu, elapsed = elapsed, retries = retries,
     imports_only = imports_only, skip_imports = skip_imports,
     skip_safety_checks = skip_safety_checks, store_meta = store_meta,
-    lazy_load = lazy_load
+    lazy_load = lazy_load, session_info = session_info
   )
 }
 

--- a/R/debug.R
+++ b/R/debug.R
@@ -6,7 +6,8 @@ dbug <- function() {
   plan <- dbug_plan()
   drake_config(plan = plan, targets = plan$target,
     envir = envir, parallelism = scenario$parallelism,
-    jobs = scenario$jobs, verbose = FALSE
+    jobs = scenario$jobs, verbose = FALSE,
+    session_info = FALSE
   )
 }
 

--- a/R/make.R
+++ b/R/make.R
@@ -246,6 +246,12 @@
 #' Lazy loading may be more memory efficient in some use cases, but
 #' it may duplicate the loading of dependencies, costing time.
 #'
+#' @param session_info logical, whether to save the \code{sessionInfo()}
+#' to the cache. This behavior is recommended for serious \code{\link{make}()}s
+#' for the sake of reproducibility. This argument only exists to
+#' speed up tests. Apparently, \code{sessionInfo()} is a bottleneck
+#' for small \code{\link{make}()}s.
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -308,7 +314,8 @@ make <- function(
   skip_safety_checks = FALSE,
   store_meta = TRUE,
   config = NULL,
-  lazy_load = FALSE
+  lazy_load = FALSE,
+  session_info = TRUE
 ){
   force(envir)
   if (!is.null(return_config)){
@@ -353,7 +360,8 @@ make <- function(
       skip_imports = skip_imports,
       skip_safety_checks = skip_safety_checks,
       store_meta = store_meta,
-      lazy_load = lazy_load
+      lazy_load = lazy_load,
+      session_info = session_info
     )
   }
   make_with_config(config = config)
@@ -456,9 +464,11 @@ targets_graph <- function(config){
 
 initialize_session <- function(config){
   config$cache$clear(namespace = "session")
-  config$cache$set(
-    key = "sessionInfo",
-    value = sessionInfo(),
-    namespace = "session"
-  )
+  if (config$session_info){
+    config$cache$set(
+      key = "sessionInfo",
+      value = sessionInfo(),
+      namespace = "session"
+    )
+  }
 }

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -66,6 +66,7 @@ migrate_drake_project <- function(
   config$execution_graph <- config$graph
   config$store_meta <- TRUE
   config$lazy_load <- FALSE
+  config$session_info <- TRUE
   config$outdated <- legacy_outdated(config) %>%
     as.character %>%
     sort

--- a/R/test.R
+++ b/R/test.R
@@ -11,7 +11,8 @@ testrun <- function(config) {
       jobs = config$jobs,
       packages = config$packages, prework = config$prework,
       prepend = config$prepend, command = config$command,
-      cache = config$cache, lazy_load = config$lazy_load
+      cache = config$cache, lazy_load = config$lazy_load,
+      session_info = config$session_info
     )
   )
 }

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -16,7 +16,7 @@ drake_config(plan = plan_drake(), targets = drake::possible_targets(plan),
   clear_progress = FALSE, graph = NULL,
   trigger = drake::default_trigger(), imports_only = FALSE,
   skip_imports = FALSE, skip_safety_checks = FALSE, store_meta = TRUE,
-  lazy_load = FALSE)
+  lazy_load = FALSE, session_info = TRUE)
 }
 \arguments{
 \item{plan}{same as for \code{\link{make}}}
@@ -80,6 +80,8 @@ on your workflow to save time. Use at your own peril.}
 \item{store_meta}{same as for \code{\link{make}}}
 
 \item{lazy_load}{same as for \code{\link{make}}}
+
+\item{session_info}{same as for \code{\link{make}}}
 }
 \value{
 The master internal configuration list of a project.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -16,7 +16,7 @@ make(plan = plan_drake(), targets = drake::possible_targets(plan),
   retries = 0, force = FALSE, return_config = NULL, graph = NULL,
   trigger = drake::default_trigger(), skip_imports = FALSE,
   skip_safety_checks = FALSE, store_meta = TRUE, config = NULL,
-  lazy_load = FALSE)
+  lazy_load = FALSE, session_info = TRUE)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -252,6 +252,12 @@ If \code{lazy_load} is \code{TRUE}, drake assigns
 promises to load any dependencies at the last minute.
 Lazy loading may be more memory efficient in some use cases, but
 it may duplicate the loading of dependencies, costing time.}
+
+\item{session_info}{logical, whether to save the \code{sessionInfo()}
+to the cache. This behavior is recommended for serious \code{\link{make}()}s
+for the sake of reproducibility. This argument only exists to
+speed up tests. Apparently, \code{sessionInfo()} is a bottleneck
+for small \code{\link{make}()}s.}
 }
 \value{
 The master internal configuration list, mostly

--- a/tests/testthat/test-Makefile.R
+++ b/tests/testthat/test-Makefile.R
@@ -62,7 +62,7 @@ test_with_dir("files inside directories can be timestamped", {
   unlink("t1", recursive = TRUE, force = TRUE)
   expect_false(file.exists("t1"))
 
-  expect_silent(make(config$plan, verbose = FALSE))
+  expect_silent(make(config$plan, verbose = FALSE, session_info = FALSE))
   expect_true(file.exists("t1"))
   expect_true(file.exists(drake::drake_unquote(file)))
   unlink("t1", recursive = TRUE, force = TRUE)
@@ -72,7 +72,7 @@ test_with_dir("files inside directories can be timestamped", {
 test_with_dir("basic Makefile stuff works", {
   config <- dbug()
   make(config$plan, targets = "combined", envir = config$envir,
-    verbose = FALSE)
+    verbose = FALSE, session_info = FALSE)
   config$verbose <- FALSE
   cache_path <- cache_path(config$cache)
   initialize_session(config = config)
@@ -125,7 +125,7 @@ test_with_dir("Makefile stuff in globalenv()", {
   drake_TESTGLOBAL_config <- make(
     drake_TESTGLOBAL_plan,
     envir = globalenv(),
-    verbose = FALSE
+    verbose = FALSE, session_info = FALSE
   )
   store_drake_config(drake_TESTGLOBAL_config)
   run_Makefile(drake_TESTGLOBAL_config, run = FALSE, debug = TRUE)
@@ -215,7 +215,7 @@ test_with_dir("packages are loaded in prework", {
   suppressWarnings(make(plan = config$plan, targets = config$targets,
     envir = config$envir, verbose = FALSE, parallelism = scenario$parallelism,
     jobs = scenario$jobs, prework = config$prework, prepend = config$prepend,
-    command = config$command
+    command = config$command, session_info = FALSE
   ))
   expect_true(all(c("x", "y") %in% config$cache$list()))
   expect_equal(readd(x, search = FALSE), "set")

--- a/tests/testthat/test-arbitrary-cache.R
+++ b/tests/testthat/test-arbitrary-cache.R
@@ -24,7 +24,7 @@ test_with_dir("storr_environment is a cache type", {
   expect_equal(long_hash(x), default_long_hash_algo())
   expect_error(drake_session(cache = x))
   pln <- plan_drake(y = 1)
-  config <- make(pln, cache = x, verbose = FALSE)
+  config <- make(pln, cache = x, verbose = FALSE, session_info = FALSE)
   expect_equal(cached(cache = x), "y")
   expect_false(file.exists(default_cache_path()))
   expect_equal(outdated(config), character(0))

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -17,12 +17,13 @@ test_with_dir("clean() works if there is no cache already", {
 
 test_with_dir("corrupt cache", {
   x <- plan_drake(a = 1)
-  make(x, verbose = FALSE)
+  make(x, verbose = FALSE, session_info = FALSE)
   path <- file.path(default_cache_path(), "config", "hash_algorithm")
   expect_true(file.exists(path))
   unlink(path)
   expect_false(file.exists(path))
-  expect_warning(expect_error(make(x, verbose = FALSE)))
+  expect_warning(expect_error(
+    make(x, verbose = FALSE, session_info = FALSE)))
 })
 
 test_with_dir("try to find a non-existent project", {
@@ -72,6 +73,7 @@ test_with_dir("cache functions work", {
     envir <- environment()
   }
 
+  config$session_info <- TRUE
   testrun(config)
 
   # drake_gc() should not remove any important targets/imports.

--- a/tests/testthat/test-console.R
+++ b/tests/testthat/test-console.R
@@ -2,11 +2,12 @@ drake_context("console")
 
 test_with_dir("console_up_to_date", {
   pl <- plan_drake(a = 1)
-  con <- make(pl, verbose = FALSE)
+  con <- make(pl, verbose = FALSE, session_info = FALSE)
   expect_silent(console_up_to_date(con))
   con$verbose <- TRUE
   expect_silent(console_up_to_date(con))
-  con <- make(pl, verbose = FALSE)
+  con$cache$clear(namespace = "session")
+  con <- make(pl, verbose = FALSE, session_info = FALSE)
   con$verbose <- TRUE
   expect_message(console_up_to_date(con))
 })

--- a/tests/testthat/test-custom-caches.R
+++ b/tests/testthat/test-custom-caches.R
@@ -107,7 +107,8 @@ test_with_dir("totally off the default cache", {
     cache = con$cache,
     verbose = FALSE,
     parallelism = get_testing_scenario()$parallelism,
-    jobs = get_testing_scenario()$jobs
+    jobs = get_testing_scenario()$jobs,
+    session_info = FALSE
   )
   expect_false(file.exists(default_cache_path()))
 })
@@ -134,7 +135,8 @@ test_with_dir("use two differnt file system caches", {
     envir = envir,
     verbose = FALSE,
     parallelism = parallelism,
-    jobs = jobs
+    jobs = jobs,
+    session_info = FALSE
   )
 
   o1 <- outdated(con)
@@ -172,7 +174,8 @@ test_with_dir("use two differnt file system caches", {
     envir = envir,
     verbose = FALSE,
     parallelism = parallelism,
-    jobs = jobs
+    jobs = jobs,
+    session_info = FALSE
   )
   o3 <- outdated(con2)
   expect_equal(o2, targ)

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -7,18 +7,17 @@ test_with_dir("deprecation: future", {
 test_with_dir("deprecation: make() and config()", {
   expect_warning(default_system2_args(jobs = 1, verbose = FALSE))
   expect_warning(make(plan_drake(x = 1), return_config = TRUE,
-    verbose = FALSE))
+    verbose = FALSE, session_info = FALSE))
   expect_warning(make(plan_drake(x = 1), clear_progress = TRUE,
-    verbose = FALSE))
+    verbose = FALSE, session_info = FALSE))
   expect_warning(config(plan_drake(x = 1)))
 })
 
 test_with_dir("deprecation: cache functions", {
   plan <- plan_drake(x = 1)
-  expect_silent(make(plan, verbose = FALSE))
+  expect_silent(make(plan, verbose = FALSE, session_info = FALSE))
   expect_true(is.numeric(readd(x, search = FALSE)))
   expect_equal(cached(), "x")
-  expect_warning(session())
   expect_warning(read_config())
   expect_warning(read_graph())
   expect_warning(read_plan())
@@ -42,6 +41,7 @@ test_with_dir("drake version checks in previous caches", {
   plan <- plan_drake(x = 1)
   expect_silent(make(plan, verbose = FALSE))
   x <- get_cache()
+  expect_warning(session())
   x$del(key = "initial_drake_version", namespace = "session")
   expect_false("initial_drake_version" %in% x$list(namespace = "session"))
   set_initial_drake_version(cache = x)

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -10,7 +10,7 @@ test_with_dir("config and make without safety checks", {
 
 test_with_dir("Strings stay strings, not symbols", {
   x <- plan_drake(a = "A", strings_in_dots = "literals")
-  expect_silent(make(x, verbose = FALSE))
+  expect_silent(make(x, verbose = FALSE, session_info = FALSE))
 })
 
 test_with_dir("error handlers", {
@@ -21,7 +21,7 @@ test_with_dir("error handlers", {
 
 test_with_dir("error when file target names do not match actual filenames", {
   x <- plan_drake(y = 1, file_targets = TRUE)
-  expect_warning(expect_error(make(x, verbose = FALSE)))
+  expect_warning(expect_error(make(x, verbose = FALSE, session_info = FALSE)))
 })
 
 test_with_dir("clean a nonexistent cache", {
@@ -37,7 +37,7 @@ test_with_dir("stringsAsFactors can be TRUE", {
     stringsAsFactors = TRUE)
   expect_true(is.factor(myplan$target))
   expect_true(is.factor(myplan$command))
-  make(myplan, verbose = FALSE)
+  make(myplan, verbose = FALSE, session_info = FALSE)
   expect_equal(readd(a), "helloworld")
 })
 
@@ -67,7 +67,7 @@ test_with_dir("target conflicts with previous import", {
 
 test_with_dir("can use semicolons and multi-line commands", {
   plan <- plan_drake(list = c(x = "a<-1; a", y = "b<-2\nb"))
-  make(plan, verbose = FALSE)
+  make(plan, verbose = FALSE, session_info = FALSE)
   expect_false(any(c("a", "b") %in% ls()))
   expect_true(all(cached(x, y, search = FALSE)))
   expect_equal(cached(search = FALSE), c("x", "y"))
@@ -78,7 +78,7 @@ test_with_dir("true targets can be functions", {
     x + 1
   })
   plan <- plan_drake(myfunction = generator(), output = myfunction(1))
-  config <- make(plan, verbose = FALSE)
+  config <- make(plan, verbose = FALSE, session_info = FALSE)
   expect_equal(readd(output), 2)
   expect_true(
     is.character(

--- a/tests/testthat/test-full-build.R
+++ b/tests/testthat/test-full-build.R
@@ -18,8 +18,8 @@ test_with_dir("scratch build with custom filesystem cache.", {
   expect_true(is.numeric(readd(final, cache = cache)))
   expect_true(length(config$cache$list()) > 2)
   expect_false(any(c("f", "final") %in% ls()))
-  expect_true(is.list(drake_session(cache = cache)))
-  expect_true(all(drake_session(cache = cache)$target %in% config$plan$target))
+  expect_true(
+    all(read_drake_plan(cache = cache)$target %in% config$plan$target))
 
   cache <- this_cache(path = path)
   expect_equal(short_hash(cache), "murmur32")

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -13,7 +13,8 @@ test_with_dir("future package functionality", {
           envir = e,
           parallelism = "future_lapply",
           jobs = 1,
-          verbose = FALSE
+          verbose = FALSE,
+          session_info = FALSE
         )
       }
     )

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -9,7 +9,7 @@ test_with_dir("drake searches past outdated targets for parallel stages", {
     c = a,
     f = c
   )
-  config <- make(plan, targets = c("a", "b", "c", "d"))
+  config <- make(plan, targets = c("a", "b", "c", "d"), session_info = FALSE)
   config <- drake_config(plan)
   stages <- parallel_stages(config)
   expect_equal(sort(stages$item), c("e", "f"))
@@ -37,7 +37,7 @@ test_with_dir("null graph", {
 test_with_dir("circular non-DAG plan_drakes quit in error", {
   p <- plan_drake(a = b, b = c, c = a)
   expect_error(tmp <- capture.output(check_plan(p)))
-  expect_error(make(p, verbose = FALSE))
+  expect_error(make(p, verbose = FALSE, session_info = FALSE))
 })
 
 test_with_dir("Supplied graph disagrees with the workflow plan", {
@@ -48,7 +48,8 @@ test_with_dir("Supplied graph disagrees with the workflow plan", {
       plan = con$plan,
       envir = con$envir,
       graph = con2$graph,
-      verbose = FALSE
+      verbose = FALSE,
+      session_info = FALSE
     )
   )
 })

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -8,8 +8,20 @@ test_with_dir("available hash algos", {
 
 test_with_dir("illegal hashes", {
   x <- plan_drake(a = 1)
-  expect_error(make(x, short_hash_algo = "no_such_algo_aslkdjfoiewlk"))
-  expect_error(make(x, long_hash_algo = "no_such_algo_aslkdjfoiewlk"))
+  expect_error(
+    make(
+      x,
+      short_hash_algo = "no_such_algo_aslkdjfoiewlk",
+      session_info = FALSE
+    )
+  )
+  expect_error(
+    make(
+      x,
+      long_hash_algo = "no_such_algo_aslkdjfoiewlk",
+      session_info = FALSE
+    )
+  )
 })
 
 test_with_dir("stress test file hash", {

--- a/tests/testthat/test-lazy-load.R
+++ b/tests/testthat/test-lazy-load.R
@@ -44,7 +44,8 @@ test_with_dir("lazy loading is actually lazy", {
     plan = config$plan,
     targets = "combined",
     envir = config$envir,
-    verbose = FALSE
+    verbose = FALSE,
+    session_info = FALSE
   )
   loaded <- ls(envir = config$envir)
   expect_true(all(lazily_loaded %in% loaded))
@@ -55,7 +56,8 @@ test_with_dir("lazy loading is actually lazy", {
     plan = config$plan,
     targets = "combined",
     envir = config$envir,
-    verbose = FALSE
+    verbose = FALSE,
+    session_info = FALSE
   )
   loaded <- ls(envir = config$envir)
   expect_true(all(lazily_loaded %in% loaded))

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -16,7 +16,7 @@ test_with_dir("force loading a non-back-compatible cache", {
   expect_true(inherits(recover_cache(force = TRUE), "storr"))
   config <- load_basic_example(force = TRUE)
   expect_true(length(outdated(config)) > 0)
-  expect_error(make(my_plan, verbose = FALSE))
+  expect_error(make(my_plan, verbose = FALSE, session_info = FALSE))
   make(my_plan, verbose = FALSE, force = TRUE)
   expect_equal(outdated(config), character(0))
   expect_true(length(cached()) > 0)
@@ -38,7 +38,7 @@ test_with_dir("migrate_drake_project() an up to date cache", {
   cache <- this_cache(path = "old", force = TRUE)
   expect_true(migrate_drake_project(path = "old", jobs = 2))
   load_basic_example()
-  config <- make(my_plan, cache = cache)
+  config <- make(my_plan, cache = cache, session_info = FALSE)
  # expect_equal(justbuilt(config = config), character(0)) # r-lib/covr#289 # nolint
   clean(cache = cache)
   expect_equal(cached(cache = cache), character(0))

--- a/tests/testthat/test-namespaced.R
+++ b/tests/testthat/test-namespaced.R
@@ -60,7 +60,8 @@ test_with_dir("namespaced plan_drake works", {
     envir = envir,
     jobs = scenarios$jobs,
     parallelism = scenarios$parallelism,
-    verbose = FALSE
+    verbose = FALSE,
+    session_info = FALSE
   )
   fromcache <- readd("base::list", character_only = TRUE)
   expect_equal(fromcache(1, "a"), list(1, "a"))

--- a/tests/testthat/test-other-features.R
+++ b/tests/testthat/test-other-features.R
@@ -25,7 +25,7 @@ test_with_dir("shapes", {
 
 test_with_dir("make() with imports_only", {
   expect_silent(make(plan_drake(x = 1), imports_only = TRUE,
-    verbose = FALSE))
+    verbose = FALSE, session_info = FALSE))
   expect_false(cached(x))
 })
 
@@ -33,7 +33,7 @@ test_with_dir("in_progress() works", {
   expect_equal(in_progress(), character(0))
   bad_plan <- plan_drake(x = function_doesnt_exist())
   expect_error(tmp <- capture.output({
-      make(bad_plan, verbose = FALSE)
+      make(bad_plan, verbose = FALSE, session_info = FALSE)
     },
     type = "message")
   )
@@ -68,17 +68,23 @@ test_with_dir("check_drake_config() via check_plan() and make()", {
   config <- dbug()
   y <- data.frame(x = 1, y = 2)
   expect_error(check_plan(y, envir = config$envir))
-  expect_error(make(y, envir = config$envir))
+  expect_error(make(y, envir = config$envir, session_info = FALSE))
   y <- data.frame(target = character(0), command = character(0))
   expect_error(check_plan(y, envir = config$envir))
-  expect_error(make(y, envir = config$envir))
+  expect_error(make(y, envir = config$envir, session_info = FALSE))
   expect_error(
     check_plan(config$plan, targets = character(0), envir = config$envir))
   expect_error(
-    make(config$plan, targets = character(0), envir = config$envir))
+    make(
+      config$plan,
+      targets = character(0),
+      envir = config$envir,
+      session_info = FALSE
+    )
+  )
   y <- plan_drake(x = 1, y = 2)
   y$bla <- "bluh"
-  expect_warning(make(y))
+  expect_warning(make(y, session_info = FALSE))
 })
 
 test_with_dir("targets can be partially specified", {

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -45,25 +45,25 @@ test_with_dir("shell_file() writes correctly", {
 test_with_dir("mclapply and lapply", {
   config <- dbug()
   make(plan = config$plan, envir = config$envir, verbose = FALSE,
-    jobs = 1, parallelism = "mclapply")
+    jobs = 1, parallelism = "mclapply", session_info = FALSE)
   expect_true(is.numeric(readd(final)))
   clean()
 
   # should demote to 1 job on Windows
   suppressWarnings(
     make(plan = config$plan, envir = config$envir, verbose = FALSE,
-      jobs = 2, parallelism = "mclapply")
+      jobs = 2, parallelism = "mclapply", session_info = FALSE)
   )
   expect_true(is.numeric(readd(final)))
   clean()
 
   make(plan = config$plan, envir = config$envir, verbose = FALSE,
-    jobs = 2, parallelism = "parLapply")
+    jobs = 2, parallelism = "parLapply", session_info = FALSE)
   expect_true(is.numeric(readd(final)))
   clean()
 
   make(plan = config$plan, envir = config$envir, verbose = FALSE,
-    jobs = 1, parallelism = "parLapply")
+    jobs = 1, parallelism = "parLapply", session_info = FALSE)
   expect_true(is.numeric(readd(final)))
 })
 

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -23,7 +23,8 @@ test_with_dir("Random targets are reproducible", {
     envir = env,
     parallelism = parallelism,
     jobs = jobs,
-    verbose = FALSE
+    verbose = FALSE,
+    session_info = FALSE
   )
   old_x <- readd(x)
   old_y <- readd(y)
@@ -40,7 +41,8 @@ test_with_dir("Random targets are reproducible", {
     envir = env,
     parallelism = parallelism,
     jobs = jobs,
-    verbose = FALSE
+    verbose = FALSE,
+    session_info = FALSE
   )
 
   expect_identical(con$seed, con2$seed)
@@ -59,7 +61,8 @@ test_with_dir("Random targets are reproducible", {
     envir = env,
     parallelism = parallelism,
     jobs = jobs,
-    verbose = FALSE
+    verbose = FALSE,
+    session_info = FALSE
   )
   expect_false(identical(con$seed, con3$seed))
   expect_false(identical(readd(x), old_x))

--- a/tests/testthat/test-retry.R
+++ b/tests/testthat/test-retry.R
@@ -32,7 +32,7 @@ test_with_dir("retries", {
   make(
     pl, parallelism = parallelism, jobs = jobs,
     envir = e, retries = 10, verbose = FALSE,
-    hook = silencer_hook
+    hook = silencer_hook, session_info = FALSE
   )
   debrief_retries()
 
@@ -44,7 +44,7 @@ test_with_dir("retries", {
   make(
     pl, parallelism = parallelism, jobs = jobs,
     envir = e, retries = 0, verbose = FALSE,
-    hook = silencer_hook
+    hook = silencer_hook, session_info = FALSE
   )
   debrief_retries()
 })
@@ -65,7 +65,8 @@ test_with_dir("timeouts", {
       pl,
       envir = e,
       verbose = TRUE,
-      hook = silencer_hook
+      hook = silencer_hook,
+      session_info = FALSE
     )
   )
   expect_true(cached(x))
@@ -80,7 +81,8 @@ test_with_dir("timeouts", {
         verbose = TRUE,
         hook = silencer_hook,
         timeout = 1e-3,
-        retries = 2
+        retries = 2,
+        session_info = FALSE
       )
     )
   )

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -22,12 +22,12 @@ test_with_dir("build times works if no targets are built", {
 
 test_with_dir("build time the same after superfluous make", {
   x <- plan_drake(y = Sys.sleep(0.25))
-  c1 <- make(x, verbose = FALSE)
+  c1 <- make(x, verbose = FALSE, session_info = FALSE)
   expect_equal(justbuilt(c1), "y")
   b1 <- build_times(search = FALSE)
   expect_true(all(complete.cases(b1)))
 
-  c2 <- make(x, verbose = FALSE)
+  c2 <- make(x, verbose = FALSE, session_info = FALSE)
   expect_equal(justbuilt(c2), character(0))
   b2 <- build_times(search = FALSE)
   expect_true(all(complete.cases(b2)))
@@ -48,7 +48,7 @@ test_with_dir("empty time predictions", {
       min_df
   )
   expect_equal(nrow(x), 0)
-  config <- make(my_plan, verbose = FALSE)
+  config <- make(my_plan, verbose = FALSE, session_info = FALSE)
   x <- rate_limiting_times(config) %>%
     min_df
   expect_equal(nrow(x), 0)

--- a/tests/testthat/test-triggers.R
+++ b/tests/testthat/test-triggers.R
@@ -61,25 +61,26 @@ test_with_dir("triggers work as expected", {
   con$plan$trigger <- NULL
   con <- make(
     con$plan, trigger = "missing",
-    envir = con$envir, verbose = TRUE)
+    envir = con$envir, verbose = TRUE, session_info = FALSE)
   expect_equal(justbuilt(con), character(0))
 
   # Global trigger is overridden
   con$plan$trigger <- "missing"
   con <- make(
     con$plan, trigger = "command",
-    envir = con$envir, verbose = TRUE)
+    envir = con$envir, verbose = TRUE, session_info = FALSE)
   expect_equal(justbuilt(con), character(0))
 
   # 'always' trigger rebuilts up-to-date targets
   con$plan$trigger <- "any"
-  con <- make(con$plan, envir = con$envir)
+  con <- make(con$plan, envir = con$envir, session_info = FALSE)
   out <- outdated(con)
   expect_equal(out, character(0))
   con$plan$trigger[con$plan$target == "final"] <- "always"
   con2 <- make(
     con$plan, parallelism = con$parallelism,
-    envir = con$envir, jobs = con$jobs, verbose = FALSE)
+    envir = con$envir, jobs = con$jobs, verbose = FALSE,
+    session_info = FALSE)
   expect_equal(justbuilt(con2), "final")
 })
 
@@ -90,7 +91,8 @@ test_with_dir("all triggers bring targets up to date", {
     con$plan$trigger <- trigger
     con <- make(
       con$plan, parallelism = con$parallelism,
-      envir = con$envir, jobs = con$jobs, verbose = FALSE)
+      envir = con$envir, jobs = con$jobs, verbose = FALSE,
+      session_info = FALSE)
     expect_equal(sort(justbuilt(con)), sort(con$plan$target))
     con$plan$trigger <- NULL
     out <- outdated(con)
@@ -107,21 +109,22 @@ test_with_dir("make(..., skip_imports = TRUE) works", {
       con$plan, parallelism = con$parallelism,
       envir = con$envir, jobs = con$jobs, verbose = verbose,
       hook = silencer_hook,
-      skip_imports = TRUE
+      skip_imports = TRUE,
+      session_info = FALSE
     )
   )
   expect_equal(sort(cached()), sort(con$plan$target))
 
   # If the imports are already cached, the targets built with
   # skip_imports = TRUE should be up to date.
-  make(con$plan, verbose = FALSE, envir = con$envir)
+  make(con$plan, verbose = FALSE, envir = con$envir, session_info = FALSE)
   clean(list = con$plan$target, verbose = FALSE)
   suppressMessages(
     con <- make(
       con$plan, parallelism = con$parallelism,
       envir = con$envir, jobs = con$jobs, verbose = verbose,
       hook = silencer_hook,
-      skip_imports = TRUE
+      skip_imports = TRUE, session_info = FALSE
     )
   )
   out <- outdated(con)

--- a/tests/testthat/test-workflow-plan.R
+++ b/tests/testthat/test-workflow-plan.R
@@ -70,14 +70,14 @@ test_with_dir("plan_drake() trims outer whitespace in target names", {
 test_with_dir("make() and check_plan() trim outer whitespace in target names", {
   x <- data.frame(target = c("a\n", "  b", "c ", "\t  d   "),
     command = 1)
-  expect_silent(make(x, verbose = FALSE))
+  expect_silent(make(x, verbose = FALSE, session_info = FALSE))
   expect_equal(sort(cached()), letters[1:4])
   stat <- c(a = "finished", b = "finished", c = "finished",
     d = "finished")
   expect_equal(progress(), stat)
 
   expect_warning(make(x, verbose = FALSE, targets = c("a",
-    "nobody_home")))
+    "nobody_home"), session_info = FALSE))
 
   x <- data.frame(target = c("a", " a"), command = 1)
   expect_error(check_plan(x, verbose = FALSE))
@@ -89,7 +89,7 @@ test_with_dir("make() plays nicely with tibbles", {
   }
   x <- tibble::tribble(~target, ~command, "nothing", 1)
   expect_silent(check_plan(x, verbose = FALSE))
-  expect_silent(make(x, verbose = FALSE))
+  expect_silent(make(x, verbose = FALSE, session_info = FALSE))
 })
 
 test_with_dir("check_plan() finds bad symbols", {


### PR DESCRIPTION
Rate-limiting step for small `make()`s. Trying to speed up tests.